### PR TITLE
Update URL for upstream data

### DIFF
--- a/update_reminder.sh
+++ b/update_reminder.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 MARKT_LAST_CHANGE=$(wget -q -O- https://wo-ist-markt.de/cities/berlin.json | sed -n 's/.*aktualisiert am \(.*\)",/\1/p')
-BERLIN_LAST_CHANGE=$(wget -q -O- https://daten.berlin.de/datensaetze/wochen-und-tr%C3%B6delm%C3%A4rkte-0 | sed -n '/.*Aktualisiert.*/,$p' | sed -e '/.*end.*/,$d' | sed -n 's/.*<span .*>\(.*\)<\/span.*/\1/p')
+BERLIN_LAST_CHANGE=$(wget -q -O- https://daten.berlin.de/datensaetze/wochen-und-trödelmärkte | sed -n '/.*Aktualisiert.*/,$p' | sed -e '/.*end.*/,$d' | sed -n 's/.*<span .*>\(.*\)<\/span.*/\1/p')
 
 if [[ "$MARKT_LAST_CHANGE" != "$BERLIN_LAST_CHANGE" ]]; then
   echo "Dates don't match!"


### PR DESCRIPTION
There was a big update of the daten.berlin.de which also slightly
changed the url under which this dataset is made available.